### PR TITLE
Add CountAPI service and wire up home component

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,6 +6,7 @@ import { MainComponent } from "./main/main.component";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { CarouselModule } from "ngx-owl-carousel-o";
 import { RouterModule } from "@angular/router";
+import { HttpClientModule } from "@angular/common/http";
 import { HomeComponent } from "./main/home/home.component";
 import { AboutComponent } from "./main/about/about.component";
 import { ExperienceComponent } from "./main/experience/experience.component";
@@ -34,6 +35,7 @@ import { AngularFireModule } from "@angular/fire/compat";
     RouterModule,
     BrowserAnimationsModule,
     CarouselModule,
+    HttpClientModule,
     ScrollSpyModule,
     NgClickOutsideDirective,
     AngularFireModule.initializeApp(environment.firebaseConfig),

--- a/src/app/main/home/home.component.html
+++ b/src/app/main/home/home.component.html
@@ -16,9 +16,9 @@
           <a class="px-btn" href="#contact">
             Work with me <i class="bi-arrow-up-right"></i>
           </a>
-          <!-- <span class="bi-envelope" id="count" style="margin-left: 16px"
-            >Loading...</span -->
-          >
+          <span class="bi-envelope" style="margin-left: 16px">
+            {{ visitCount === null ? 'Loading...' : visitCount }}
+          </span>
         </div>
         <div class="info-bar">
           <p><i class="bi-phone"></i> <span>+1945 236 9965</span></p>
@@ -50,20 +50,3 @@
     ></a>
   </div>
 </div>
-<script>
-  // Replace 'your-unique-key' with your actual key
-  const countAPIUrl = "https://api.countapi.xyz/hit/hunpeo97.web.app/visits";
-
-  // Function to update visit count
-  function updateVisitCount() {
-    fetch(countAPIUrl)
-      .then((response) => response.json())
-      .then((data) => {
-        document.getElementById("count").innerText = data.value;
-      })
-      .catch((error) => console.error("Error fetching visit count:", error));
-  }
-
-  // Update visit count on page load
-  updateVisitCount();
-</script>

--- a/src/app/main/home/home.component.ts
+++ b/src/app/main/home/home.component.ts
@@ -1,10 +1,20 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { VisitCountService } from '../../visit-count.service';
 
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss']
 })
-export class HomeComponent {
+export class HomeComponent implements OnInit {
+  visitCount: number | null = null;
 
+  constructor(private visitCountService: VisitCountService) {}
+
+  ngOnInit(): void {
+    this.visitCountService.getVisitCount().subscribe({
+      next: (count) => (this.visitCount = count),
+      error: (err) => console.error('Error fetching visit count', err),
+    });
+  }
 }

--- a/src/app/visit-count.service.ts
+++ b/src/app/visit-count.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, map } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class VisitCountService {
+  private readonly countAPIUrl =
+    'https://api.countapi.xyz/hit/hunpeo97.web.app/visits';
+
+  constructor(private http: HttpClient) {}
+
+  getVisitCount(): Observable<number> {
+    return this.http
+      .get<{ value: number }>(this.countAPIUrl)
+      .pipe(map((res) => res.value));
+  }
+}


### PR DESCRIPTION
## Summary
- create `VisitCountService` to fetch hit counter
- display visit count with Angular binding in home component
- import `HttpClientModule` to enable HTTP requests

## Testing
- `npm test -- --no-watch --no-progress --browsers=ChromeHeadless` *(fails: Could not find '@angular-devkit/build-angular:karma' builder)*

------
https://chatgpt.com/codex/tasks/task_e_688c8fbfcd148326bcb0b27f4b8107d4